### PR TITLE
fix: build solo mode image with MCP server

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,13 +57,24 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
-      - name: Build and push API image
+      - name: Build and push API image (team mode)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile.api
           push: true
           platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/merewhiplash/engram-cogitator-api:${{ steps.version.outputs.VERSION }}
+            ghcr.io/merewhiplash/engram-cogitator-api:latest
+
+      - name: Build and push solo image (solo mode with MCP server)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/amd64
           tags: |
             ghcr.io/merewhiplash/engram-cogitator:${{ steps.version.outputs.VERSION }}
             ghcr.io/merewhiplash/engram-cogitator:latest


### PR DESCRIPTION
## Summary

Fixes the install script failing with "no such file or directory" for `/usr/local/bin/engram-cogitator`.

The release workflow was building from `Dockerfile.api` which only contains the team mode API server. The install script expects the MCP server binary.

## Changes

- Main image (`engram-cogitator`) now builds from `Dockerfile` which includes MCP server
- API image renamed to `engram-cogitator-api` for team mode
- Solo mode image only builds `linux/amd64` (CGO requirement for SQLite)

## Test plan

- [ ] Merge and tag v0.3.1
- [ ] Verify Docker image contains `/usr/local/bin/engram-cogitator`
- [ ] Run install script and confirm MCP connects