### PR TITLE
fix: add ARM64 support for solo mode Docker image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,13 +68,16 @@ jobs:
             ghcr.io/merewhiplash/engram-cogitator-api:${{ steps.version.outputs.VERSION }}
             ghcr.io/merewhiplash/engram-cogitator-api:latest
 
+      - name: Set up QEMU (for ARM64 CGO builds)
+        uses: docker/setup-qemu-action@v3
+
       - name: Build and push solo image (solo mode with MCP server)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/merewhiplash/engram-cogitator:${{ steps.version.outputs.VERSION }}
             ghcr.io/merewhiplash/engram-cogitator:latest


### PR DESCRIPTION
## Summary

Apple Silicon users getting "no matching manifest for linux/arm64" errors.

## Changes

- Add QEMU setup step for cross-platform CGO builds
- Enable `linux/arm64` platform for solo mode image

## Test plan

- [ ] Merge and tag v0.3.2
- [ ] Verify ARM64 manifest exists: `docker manifest inspect ghcr.io/merewhiplash/engram-cogitator:latest`
- [ ] Test on Apple Silicon