### PR TITLE
feat(cogitation): customizable workflow — overlay manifest, sizing triage, customising + sketching skills

### DIFF
--- a/cogitation/.claude-plugin/plugin.json
+++ b/cogitation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cogitation",
   "description": "Opinionated development workflows powered by Engram Cogitator's persistent semantic memory. Requires EC to be running.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": {
     "name": "MereWhiplash"
   },

--- a/cogitation/hooks/session-start.bats
+++ b/cogitation/hooks/session-start.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+# Tests for the SessionStart hook's workflow-config plumbing.
+# Run from the repo root: bats cogitation/hooks/session-start.bats
+# EC_COG_CONFIG points the hook at a fixture config for side-effect-free runs.
+
+setup() { TMP="$(mktemp -d)"; }
+teardown() { rm -rf "$TMP"; }
+
+@test "no config: injects the default-profile nudge" {
+  EC_COG_CONFIG="$TMP/missing.json" run bash cogitation/hooks/session-start.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"customise"* ]]
+  [[ "$output" == *"default cogitation profile"* ]]
+}

--- a/cogitation/hooks/session-start.bats
+++ b/cogitation/hooks/session-start.bats
@@ -12,3 +12,10 @@ teardown() { rm -rf "$TMP"; }
   [[ "$output" == *"customise"* ]]
   [[ "$output" == *"default cogitation profile"* ]]
 }
+
+@test "customized=true: no nudge" {
+  printf '{"workflow":{"customized":true}}' > "$TMP/c.json"
+  EC_COG_CONFIG="$TMP/c.json" run bash cogitation/hooks/session-start.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"default cogitation profile"* ]]
+}

--- a/cogitation/hooks/session-start.bats
+++ b/cogitation/hooks/session-start.bats
@@ -42,6 +42,18 @@ teardown() { rm -rf "$TMP"; }
   [[ "$output" == *"default cogitation profile"* ]]
 }
 
+@test "wrong-typed but valid JSON: degrades, no crash" {
+  printf '{"workflow":"nope"}' > "$TMP/c.json"
+  EC_COG_CONFIG="$TMP/c.json" run bash cogitation/hooks/session-start.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"default cogitation profile"* ]]
+
+  printf '{"workflow":{"customized":true,"skills":"nope"}}' > "$TMP/c.json"
+  EC_COG_CONFIG="$TMP/c.json" run bash cogitation/hooks/session-start.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hookSpecificOutput"* ]]
+}
+
 @test "hook passes shellcheck" {
   run shellcheck cogitation/hooks/session-start.sh
   [ "$status" -eq 0 ]

--- a/cogitation/hooks/session-start.bats
+++ b/cogitation/hooks/session-start.bats
@@ -34,3 +34,15 @@ teardown() { rm -rf "$TMP"; }
   [ "$status" -eq 0 ]
   [[ "$output" == *"\`finishing-branch\` is DISABLED"* ]]
 }
+
+@test "malformed config: treated as uncustomized, no crash" {
+  printf 'not json {{{' > "$TMP/bad.json"
+  EC_COG_CONFIG="$TMP/bad.json" run bash cogitation/hooks/session-start.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"default cogitation profile"* ]]
+}
+
+@test "hook passes shellcheck" {
+  run shellcheck cogitation/hooks/session-start.sh
+  [ "$status" -eq 0 ]
+}

--- a/cogitation/hooks/session-start.bats
+++ b/cogitation/hooks/session-start.bats
@@ -19,3 +19,11 @@ teardown() { rm -rf "$TMP"; }
   [ "$status" -eq 0 ]
   [[ "$output" != *"default cogitation profile"* ]]
 }
+
+@test "advisory rigidity emits a posture line; strict does not" {
+  printf '{"workflow":{"customized":true,"skills":{"tdd":{"rigidity":"advisory"},"verifying":{"rigidity":"strict"}}}}' > "$TMP/c.json"
+  EC_COG_CONFIG="$TMP/c.json" run bash cogitation/hooks/session-start.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"\`tdd\` rigidity is **advisory**"* ]]
+  [[ "$output" != *"\`verifying\` rigidity"* ]]   # strict is the default → no line
+}

--- a/cogitation/hooks/session-start.bats
+++ b/cogitation/hooks/session-start.bats
@@ -27,3 +27,10 @@ teardown() { rm -rf "$TMP"; }
   [[ "$output" == *"\`tdd\` rigidity is **advisory**"* ]]
   [[ "$output" != *"\`verifying\` rigidity"* ]]   # strict is the default → no line
 }
+
+@test "enabled:false emits a DISABLED posture line" {
+  printf '{"workflow":{"customized":true,"skills":{"finishing-branch":{"enabled":false}}}}' > "$TMP/c.json"
+  EC_COG_CONFIG="$TMP/c.json" run bash cogitation/hooks/session-start.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"\`finishing-branch\` is DISABLED"* ]]
+}

--- a/cogitation/hooks/session-start.sh
+++ b/cogitation/hooks/session-start.sh
@@ -37,8 +37,12 @@ if raw:
         cfg = {}
 if not isinstance(cfg, dict):
     cfg = {}
-workflow = cfg.get("workflow") or {}
-skills = workflow.get("skills") or {}
+workflow = cfg.get("workflow")
+if not isinstance(workflow, dict):
+    workflow = {}
+skills = workflow.get("skills")
+if not isinstance(skills, dict):
+    skills = {}
 customized = bool(workflow.get("customized"))
 
 posture = []

--- a/cogitation/hooks/session-start.sh
+++ b/cogitation/hooks/session-start.sh
@@ -14,12 +14,61 @@ SKILL="${PLUGIN_ROOT}/skills/using-cogitation/SKILL.md"
 
 command -v python3 >/dev/null 2>&1 || exit 0
 
-python3 - "$SKILL" <<'PY'
+# Workflow overlay: deltas-only manifest resolved into injected posture.
+# EC_COG_CONFIG overrides the config path for side-effect-free tests.
+COG_CONFIG="${EC_COG_CONFIG:-${CLAUDE_PROJECT_DIR:-$PWD}/.cogitation/config.json}"
+
+python3 - "$SKILL" "$COG_CONFIG" <<'PY'
 import json, sys
-try:
-    body = open(sys.argv[1], encoding="utf-8").read()
-except Exception:
-    body = "Error reading using-cogitation skill"
+
+def read(path):
+    try:
+        return open(path, encoding="utf-8").read()
+    except Exception:
+        return None
+
+skill_body = read(sys.argv[1]) or "Error reading using-cogitation skill"
+cfg = {}
+raw = read(sys.argv[2]) if len(sys.argv) > 2 else None
+if raw:
+    try:
+        cfg = json.loads(raw)
+    except Exception:
+        cfg = {}
+if not isinstance(cfg, dict):
+    cfg = {}
+workflow = cfg.get("workflow") or {}
+skills = workflow.get("skills") or {}
+customized = bool(workflow.get("customized"))
+
+posture = []
+for name, delta in sorted(skills.items()):
+    if not isinstance(delta, dict):
+        continue
+    if delta.get("enabled") is False:
+        posture.append(f"- `{name}` is DISABLED in this project — do not route to it.")
+        continue
+    rig = delta.get("rigidity")
+    if rig and rig != "strict":
+        posture.append(
+            f"- `{name}` rigidity is **{rig}** in this project — "
+            f"treat its discipline as {rig}, not mandatory."
+        )
+
+sections = []
+if posture:
+    sections.append(
+        "## Active workflow posture (resolved from .cogitation/config.json)\n"
+        "Apply these per-skill overrides when routing:\n" + "\n".join(posture)
+    )
+if not customized:
+    sections.append(
+        "## You are on the default cogitation profile\n"
+        "This project has not been customized — the workflow is the opinionated "
+        "default. To tailor which skills run and how strict they are, say "
+        "**customise**; cogitation will walk you through it and not nag again."
+    )
+
 intro = (
     "<EXTREMELY_IMPORTANT>\n"
     "This project uses the cogitation workflow. Below is the full content of your "
@@ -27,11 +76,10 @@ intro = (
     "build/feature/bug/review requests. For every other skill, use the Skill tool.\n"
     "</EXTREMELY_IMPORTANT>\n\n"
 )
-out = {
-    "hookSpecificOutput": {
-        "hookEventName": "SessionStart",
-        "additionalContext": intro + body,
-    }
-}
+extra = ("\n\n" + "\n\n".join(sections)) if sections else ""
+out = {"hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": intro + skill_body + extra,
+}}
 print(json.dumps(out))
 PY

--- a/cogitation/skills/cog-init/SKILL.md
+++ b/cogitation/skills/cog-init/SKILL.md
@@ -58,7 +58,7 @@ ec_search: cogitation initialized
 Create standard directories if they don't exist:
 
 ```bash
-mkdir -p docs/designs docs/plans
+mkdir -p docs/designs docs/plans docs/sketches
 ```
 
 ## Step 4: Detect Project Stack
@@ -163,6 +163,11 @@ ec_add:
   rationale: Marker for init detection
 ```
 
+**Workflow gate:** if you write `.cogitation/config.json`, leave
+`workflow.customized` **unset** — the first session then shows the one-time
+default-profile nudge, and the silent gate handles the rest. Do not force
+customization at init.
+
 ## Step 8: Summary
 
 Present what was set up:
@@ -185,3 +190,5 @@ Suggest next steps based on context:
 - New feature idea → **Use @brainstorming**
 - Existing bug → **Use @debugging**
 - Want to understand workflows → List available skills
+- Want to tailor the workflow now? → **Use @customising** (or say "customise"
+  any time — the default profile works as-is)

--- a/cogitation/skills/cog-init/cog-init.bats
+++ b/cogitation/skills/cog-init/cog-init.bats
@@ -1,0 +1,10 @@
+#!/usr/bin/env bats
+# Structural smoke test for the cog-init skill.
+# Run from the repo root: bats cogitation/skills/cog-init/cog-init.bats
+
+@test "cog-init references the workflow gate and customising handoff" {
+  run cat cogitation/skills/cog-init/SKILL.md
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"workflow"* ]]
+  [[ "$output" == *"customising"* ]]
+}

--- a/cogitation/skills/config/SKILL.md
+++ b/cogitation/skills/config/SKILL.md
@@ -124,13 +124,29 @@ A version-controlled, per-repo file. All keys optional; omitted = off. To change
 {
   "review":   { "defaultTier": "inline" },     // inline (Tier 0) | subagent (Tier 1)
   "codex":    { "enabled": false },             // Tier 2 codex-review (needs codex on PATH)
-  "graphify": { "enabled": false, "strict": true, "outDir": "graphify-out" }
+  "graphify": { "enabled": false, "strict": true, "outDir": "graphify-out" },
+  "workflow": {
+    "customized": true,                         // the silent setup gate (suppresses the nudge)
+    "skills": {
+      "tdd":              { "rigidity": "advisory" },
+      "finishing-branch": { "enabled": false }
+    }
+  }
 }
 ```
 
 - **`graphify.enabled`** — when `true`, `onboard`/`brainstorming` MUST run graphify structural recon (`graphify update .` builds the AST graph with no model/API key; then `graphify query`). When `false`/absent, graphify is never used.
 - **`codex.enabled`** — when `true`, the review ladder may escalate to `@codex-review` (docs) / `/codex:adversarial-review` (code). When `false`, stay at Tier 0/1.
 - **`review.defaultTier`** — default review tier for `executing-plans`.
+- **`workflow`** — the customization manifest, **deltas only**: it stores what
+  the user changed, never a copy of the defaults, so plugin updates flow
+  through with nothing to merge. `customized` (bool) is the silent setup gate.
+  `skills.<name>.enabled` (bool, `false` = not routed to) and
+  `skills.<name>.rigidity` (`"strict"` | `"advisory"` — advisory means
+  recommended, not mandatory). The SessionStart hook resolves these into the
+  injected posture. Prefer editing via the **customising** skill — it
+  advocates for the affected core value and records the decision in EC —
+  rather than hand-editing.
 
 ## Quick Commands
 

--- a/cogitation/skills/config/config.bats
+++ b/cogitation/skills/config/config.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+# Structural smoke test for the config skill's workflow-manifest docs.
+# Run from the repo root: bats cogitation/skills/config/config.bats
+
+@test "config skill documents the workflow manifest section" {
+  run cat cogitation/skills/config/SKILL.md
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"workflow"* ]]
+  [[ "$output" == *"rigidity"* ]]
+  [[ "$output" == *"customised"* || "$output" == *"customising"* ]]
+}

--- a/cogitation/skills/customising/SKILL.md
+++ b/cogitation/skills/customising/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: customising
+description: Use when the user wants to tailor the cogitation workflow — says "customise", "recustomise", "change the workflow", "make TDD less strict", "turn off finishing-branch", or wants a skill looser or disabled
+---
+
+# Customising
+
+Tailor the workflow to this project through a guided negotiation. You advocate
+for the core values, offer the lighter mechanism first, then yield — recording
+the user's reasoning. Deltas only; upstream files are never edited.
+
+**Announce:** "I'm using the customising skill to tailor the workflow."
+
+## The Loop
+
+```
+Listen → Map → Branch on friction → Write deltas → Set gate → Persist decision
+```
+
+## Step 0: Load Context
+
+1. Read `cogitation/values.md` (relative to the plugin root) — the six core
+   values, which skills serve each, and the pitch for each.
+2. Search prior customization decisions:
+
+```
+ec_search:
+  query: workflow customization
+  area: cogitation/customization
+  type: decision
+```
+
+If EC is down, proceed — the config file is still the source of truth.
+
+## Step 1: Listen
+
+The user describes intent in plain language ("TDD is too strict here", "we
+don't do finishing-branch", "make brainstorming advisory"). Restate what you
+heard as a concrete change: which skill(s), toggled or re-tuned how.
+
+## Step 2: Map
+
+Map each affected skill to the core value(s) it serves, using `values.md`.
+This determines the friction tier.
+
+## Step 3: Branch on Friction
+
+**HARD — continuity-of-memory only.** The one line that never yields. Do not
+offer to switch off decision-persistence (`ec_search`/`ec_add` discipline,
+`remember`). Say so plainly: "That's the one thing I can't move — without
+memory there is no cogitation, just vanilla skills." Offer to serve it
+differently (different cadence, different areas), never off.
+
+**Soft — everything else (advocate-then-yield):**
+1. **Advocate:** cite the value's pitch from `values.md` and name the concrete
+   failure mode the change re-exposes.
+2. **Offer the lighter mechanism first:** `rigidity: advisory` before
+   `enabled: false`; narrowing a skill's scope before removing it.
+3. **Yield:** if the user still wants the stronger change, make it — with an
+   explicit recorded acknowledgment ("Understood: disabling finishing-branch;
+   you accept that merge hygiene is now manual. Reason: <user's words>").
+
+## Step 4: Write Deltas
+
+Edit `.cogitation/config.json` — **deltas only**, never a copy of defaults:
+
+```json
+{
+  "workflow": {
+    "customized": true,
+    "skills": {
+      "tdd":              { "rigidity": "advisory" },
+      "finishing-branch": { "enabled": false }
+    }
+  }
+}
+```
+
+- `skills.<name>.enabled` (bool) — `false` removes it from routing.
+- `skills.<name>.rigidity` (`"strict"` | `"advisory"`) — `advisory` means the
+  discipline is recommended, not mandatory. Omit for the default (`strict`).
+- Remove a delta to restore upstream default — never write defaults out.
+
+## Step 5: Set the Gate
+
+Ensure `workflow.customized` is `true`. This permanently silences the
+first-session setup nudge. Set it even when the user reviewed the workflow and
+changed nothing — reviewing IS customizing.
+
+## Step 6: Persist the Decision
+
+```
+ec_add:
+  type: decision
+  area: cogitation/customization
+  content: [What was changed — skill, delta, and the acknowledgment if yielded]
+  rationale: [The user's own reasoning, in their words]
+```
+
+The posture takes effect at the next session start (the SessionStart hook
+resolves the deltas). Mention that.
+
+## Scope (Slice 1)
+
+Toggle + rigidity only. Adding new skills or overriding upstream ones by
+routing (`.claude/skills/` + `route:` remaps) is a future slice — say so if
+asked, and record the request in EC so demand is visible.

--- a/cogitation/skills/customising/customising.bats
+++ b/cogitation/skills/customising/customising.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+# Structural smoke test for the customising skill.
+# Run from the repo root: bats cogitation/skills/customising/customising.bats
+
+@test "customising skill has frontmatter, triggers, advocate-yield loop, hard memory line" {
+  run cat cogitation/skills/customising/SKILL.md
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"name: customising"* ]]
+  [[ "$output" == *"customise"* ]]
+  [[ "$output" == *"recustomise"* ]]
+  [[ "$output" == *"values.md"* ]]             # cites the taxonomy
+  [[ "$output" == *"lighter mechanism"* ]]     # offers softer option first
+  [[ "$output" == *"acknowledgment"* ]]        # records the yield
+  [[ "$output" == *"ec_add"* ]]                # persists the decision
+  [[ "$output" == *"customized"* ]]            # sets the gate
+  [[ "$output" == *"never"* ]]                 # memory never yields
+}

--- a/cogitation/skills/sketching/SKILL.md
+++ b/cogitation/skills/sketching/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: sketching
+description: Use for MEDIUM-sized work — new but contained behavior (one component, no architecture/data/API change) that deserves rigor without the design-doc + plan-doc ceremony of brainstorming
+---
+
+# Sketching
+
+The MEDIUM path: all of the discipline of the full flow, a fraction of the
+ceremony. One half-page combo doc replaces the design doc + plan pair; the
+execution rigor (TDD, verification, inline review) is identical.
+
+**Announce:** "I'm using the sketching skill — MEDIUM-sized work, combo doc
+instead of full design + plan."
+
+## When This Fits
+
+New behavior that is **contained**: one component, reversible-ish, no
+architecture/data-model/API-surface change. Too big for straight `@tdd`
+(there are real decisions to record), too small for `brainstorming` →
+`writing-plans` (two ceremony docs would outweigh the change).
+
+## The Flow
+
+```
+Quick Recon → Combo Doc → One Confirmation → Execute (TDD) → Persist
+```
+
+## Step 1: Quick Recon
+
+Lightweight — not the full brainstorming recon:
+
+```
+ec_search:
+  query: [feature area]
+```
+
+If graphify is enabled in `.cogitation/config.json`, one structural query on
+the touched area. Skip anything that doesn't sharpen the sketch.
+
+## Step 2: The Combo Doc
+
+Write `docs/sketches/YYYY-MM-DD-<topic>.md`, capped at **half-page**:
+
+```markdown
+# <Topic>
+
+**What/Why:** 2–3 sentences — the change and what it buys.
+**Approach:** the chosen approach, and the alternative rejected (one line on why).
+**Risks/Edges:** failure modes, empty/error states worth guarding.
+
+## Tasks
+- [ ] 1. <first task — becomes a failing test>
+- [ ] 2. <...2–5 items total, dependency order>
+```
+
+The task checklist doubles as the plan — tick items off as they complete, so a
+dead session can resume from the doc.
+
+## Step 3: One Confirmation Round
+
+Show the combo doc; get one confirmation from the user. This is a sanity
+check, not an interview — no question loop. Fold in corrections and go.
+
+## Step 4: Execute Continuously
+
+Every task follows **@tdd** (red → green → refactor), with **@verifying**
+before claiming completion and Tier 0 inline self-review at the end — the same
+discipline as `executing-plans`, none of its ceremony. Commit per task; tick
+the checklist as you go.
+
+## Escalate When It Grows
+
+Scope growth is a re-size, not a footnote. If mid-sketch you hit a one-way
+door, a new dependency, a second component, or the checklist wants a 6th task:
+**STOP, announce the re-size** ("Sizing: full — <reason>"), and escalate to
+`brainstorming`, handing over the combo doc as context. Never quietly keep
+sketching a FULL-sized change.
+
+## Step 5: Persist
+
+Durable decisions go to EC:
+
+```
+ec_add:
+  type: decision
+  area: [component]
+  content: [What was decided and why]
+  rationale: [Trade-off — including the rejected alternative]
+```
+
+The combo doc is the audit trail for the change; EC carries what future
+sessions must not re-derive.

--- a/cogitation/skills/sketching/sketching.bats
+++ b/cogitation/skills/sketching/sketching.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+# Structural smoke test for the sketching skill (MEDIUM-tier path).
+# Run from the repo root: bats cogitation/skills/sketching/sketching.bats
+
+@test "sketching skill has frontmatter, combo doc, discipline, escalation" {
+  run cat cogitation/skills/sketching/SKILL.md
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"name: sketching"* ]]
+  [[ "$output" == *"docs/sketches/"* ]]        # the combo doc home
+  [[ "$output" == *"half-page"* ]]             # size cap
+  [[ "$output" == *"rejected"* ]]              # approach + rejected alternative
+  [[ "$output" == *"checklist"* ]]             # 2–5 task checklist
+  [[ "$output" == *"tdd"* ]]                   # same execution discipline
+  [[ "$output" == *"escalate"* ]]              # one-way door → brainstorming
+  [[ "$output" == *"ec_add"* ]]                # persists decisions
+}

--- a/cogitation/skills/using-cogitation/SKILL.md
+++ b/cogitation/skills/using-cogitation/SKILL.md
@@ -8,7 +8,7 @@ If you were dispatched as a subagent to execute a specific task, skip this skill
 </SUBAGENT-STOP>
 
 <EXTREMELY-IMPORTANT>
-If there is even a 1% chance a cogitation skill applies to what you're doing, invoke it BEFORE responding — including before clarifying questions. If the skill turns out to be wrong, you can drop it. Knowing the concept is not the same as using the skill.
+If there is even a 1% chance a cogitation skill applies to what you're doing, CHECK for it BEFORE responding — including before clarifying questions. Checking now includes **sizing** (see "Size before routing") — it does not mean brainstorming for everything. If the skill turns out to be wrong, you can drop it. Knowing the concept is not the same as using the skill.
 </EXTREMELY-IMPORTANT>
 
 # Using Cogitation
@@ -27,10 +27,31 @@ If CLAUDE.md says "don't use TDD" and a skill says "always," the user wins.
 
 Use the **Skill** tool — it loads the skill content for you to follow. Never `Read` a skill file instead of invoking it. Skills evolve; don't run from memory.
 
+## Size before routing
+
+Before routing any build/change request, size it and **announce the sizing
+aloud** — `Sizing: <tier> — <reason>`. The announcement is the license to take
+a lighter path; *silent* skipping is the violation.
+
+| Tier | Test | Route |
+|---|---|---|
+| **TRIVIAL** | no behavior change — typo, rename, comment, config value, doc edit | just do it, verify after |
+| **SMALL** | behavior-preserving fix / tiny addition; **two-way door** (easily undone, no new behavior surface, no data/API/schema change) | **tdd** / **debugging** |
+| **MEDIUM** | new behavior but contained — one component, no arch/data/API change | **sketching** (half-page combo doc) |
+| **FULL** | new behavior surface, one-way door, arch/data/API | **brainstorming** → **writing-plans** |
+
+- Torn between tiers → pick the **heavier**.
+- Scope grows mid-flight (one-way door, new dependency, second component) →
+  STOP, announce the re-size, **escalate** with context in hand.
+- User vetoes a sizing → `ec_add` a learning (`area: workflow/triage`) so
+  calibration improves.
+
 ## The Workflow
 
 ```
-brainstorming → writing-plans → executing-plans → finishing-branch
+sizing → brainstorming → writing-plans → executing-plans → finishing-branch
+   │          (FULL)
+   └→ sketching (MEDIUM) · tdd/debugging (SMALL) · just do it (TRIVIAL)
                                       │
                   @tdd ·@debugging ·@verifying ·review ladder
 ```
@@ -39,7 +60,7 @@ Pick the entry point by intent:
 
 | You're about to… | Invoke |
 |---|---|
-| Build a feature / change behavior / "let's add X" | **brainstorming** (interviews you first) |
+| Build a feature / change behavior / "let's add X" | size it first — **brainstorming** (FULL) or **sketching** (MEDIUM) |
 | Turn an approved design into tasks | **writing-plans** |
 | Implement an existing plan | **executing-plans** (continuous TDD) |
 | Write any code | **tdd** (red → green → refactor) |
@@ -49,8 +70,16 @@ Pick the entry point by intent:
 | Wrap up / merge | **finishing-branch** |
 | Remember a decision/gotcha | **remember** |
 | Onboard to a repo | **onboard** · **init** (first-time setup) |
+| Tailor the workflow / change how strict it is | **customising** |
 
-**Process skills before implementation skills.** "Build X" → brainstorming first. "Fix bug" → debugging first.
+**Process skills before implementation skills.** "Build X" → size, then brainstorming or sketching. "Fix bug" → debugging first.
+
+## Workflow posture
+
+When the SessionStart hook injects an "Active workflow posture" block, apply
+those per-skill overrides when routing: a **DISABLED** skill is not routed to;
+an **advisory** skill's discipline is recommended, not mandatory. User
+instructions still win (see Instruction Priority).
 
 ## EC memory is part of the loop
 
@@ -67,7 +96,8 @@ If `.cogitation/config.json` has `graphify.enabled: true`, structural code quest
 | "This is just a simple question" | Questions are tasks. Check for a skill. |
 | "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
 | "I'll just do this one thing first" | Check BEFORE doing anything. |
-| "This is too simple to need a design" | The exact rationalization that skips brainstorming. |
+| "I'll skip the sizing announcement" | The announcement IS the license. Skipping silently is the violation. |
+| "It's *still* small" (as scope grows) | Growth is a re-size. Announce it and escalate. |
 | "I remember this skill" | Skills evolve — invoke the current version. |
 | "No production code without a failing test… but just this once" | No. @tdd is rigid. |
 

--- a/cogitation/skills/using-cogitation/using-cogitation.bats
+++ b/cogitation/skills/using-cogitation/using-cogitation.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+# Structural smoke test for the using-cogitation dispatcher.
+# Run from the repo root: bats cogitation/skills/using-cogitation/using-cogitation.bats
+
+@test "dispatcher documents posture-application and the customise path" {
+  run cat cogitation/skills/using-cogitation/SKILL.md
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"posture"* ]]          # applies injected posture
+  [[ "$output" == *"customising"* ]]      # routes the customise intent
+}
+
+@test "dispatcher documents the four-tier sizing triage" {
+  run cat cogitation/skills/using-cogitation/SKILL.md
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sizing:"* ]]          # the announced-sizing format
+  [[ "$output" == *"TRIVIAL"* ]]
+  [[ "$output" == *"SMALL"* ]]
+  [[ "$output" == *"MEDIUM"* ]]
+  [[ "$output" == *"FULL"* ]]
+  [[ "$output" == *"sketching"* ]]        # MEDIUM routes to sketching
+  [[ "$output" == *"two-way door"* ]]     # the sizing test
+  [[ "$output" == *"heavier"* ]]          # torn between tiers → heavier
+  [[ "$output" == *"escalate"* ]]         # mid-flight re-size
+  [[ "$output" != *"too simple to need a design"* ]]  # old red flag deleted
+}

--- a/cogitation/values.bats
+++ b/cogitation/values.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+# Structural smoke test for the core-values taxonomy.
+# Run from the repo root: bats cogitation/values.bats
+
+@test "values.md declares all six core values with friction tiers" {
+  run cat cogitation/values.md
+  [ "$status" -eq 0 ]
+  for v in "continuity-of-memory" "think-before-building" "prove-before-claiming" \
+           "understand-before-changing" "keep-it-simple" "small-incremental-prs"; do
+    [[ "$output" == *"$v"* ]]
+  done
+  [[ "$output" == *"HARD"* ]]   # memory is the hard line
+  [[ "$output" == *"advocate-then-yield"* ]]
+}

--- a/cogitation/values.md
+++ b/cogitation/values.md
@@ -1,0 +1,73 @@
+# Cogitation Core Values
+
+These six values are the agenda. Everything else in the workflow — every skill,
+every rule — is **downgradeable mechanism** in service of one or more of them.
+When a user weakens a mechanism, cogitation advocates for the value it serves
+(**advocate-then-yield**): exemplify what the value buys, name the failure mode
+re-exposed, offer the lighter mechanism first, then yield with a recorded
+acknowledgment. One value never yields.
+
+| Value | Friction | Served by |
+|---|---|---|
+| continuity-of-memory | **HARD** | `ec_search`/`ec_add` discipline, `remember` |
+| think-before-building | soft | `brainstorming`, `sketching`, `writing-plans` |
+| prove-before-claiming | soft | `tdd`, `verifying`, review ladder |
+| understand-before-changing | soft | `debugging`, `onboard`, graphify recon |
+| keep-it-simple | soft | YAGNI pushback in `brainstorming`/`writing-plans`, sizing triage |
+| small-incremental-prs | soft | `finishing-branch`, `requesting-review`, sizing triage |
+
+## continuity-of-memory — HARD, never yields
+
+**Serves:** every skill that searches or stores EC; `remember`.
+**The pitch:** decisions, gotchas, and rationale survive the session that
+produced them — the next session (or teammate) starts where this one ended
+instead of re-deriving or re-breaking. **Weaken it and:** there is no
+cogitation, just vanilla skills; every hard-won decision is re-litigated from
+zero. The customising skill never offers to switch decision-persistence off —
+it may be served *differently*, never abandoned. (This does NOT mean EC must be
+running: runtime graceful-degrade when EC is down is an availability fallback,
+not a customization.)
+
+## think-before-building — soft (advocate-then-yield)
+
+**Serves:** `brainstorming`, `sketching`, `writing-plans`.
+**The pitch:** ten minutes of design catches the wrong approach before it costs
+a day of rework; the interview surfaces hidden assumptions while they are still
+cheap. **Weaken it and:** first-idea architecture ships, edge cases surface in
+production, and "we'll refactor later" becomes the plan. Lighter mechanism
+first: the sizing triage already scales this — `sketching` for contained work
+before dropping design thinking entirely.
+
+## prove-before-claiming — soft (advocate-then-yield)
+
+**Serves:** `tdd`, `verifying`, the review ladder.
+**The pitch:** a failing test first means the test can fail — "done" is a
+demonstrated fact, not a feeling. **Weaken it and:** regressions land silently,
+"it works" means "it compiled," and review becomes archaeology. Lighter
+mechanism first: `rigidity: advisory` (recommended, not mandatory) before
+`enabled: false`.
+
+## understand-before-changing — soft (advocate-then-yield)
+
+**Serves:** `debugging`, `onboard`, graphify recon.
+**The pitch:** root cause before fix means the bug dies once; recon before
+edits means changes land where the code actually flows. **Weaken it and:**
+symptom-patching multiplies bugs and changes fight the architecture. Lighter
+mechanism first: keep the discipline advisory before disabling it.
+
+## keep-it-simple — soft (advocate-then-yield)
+
+**Serves:** YAGNI pushback in `brainstorming`/`writing-plans`; the sizing
+triage itself. **The pitch:** the simplest thing that works ships sooner, reads
+faster, and breaks less; complexity is bought only when the need is
+demonstrated. **Weaken it and:** speculative generality accretes until every
+change touches five abstractions. Lighter mechanism first: keep the pushback,
+soften the tone.
+
+## small-incremental-prs — soft (advocate-then-yield)
+
+**Serves:** `finishing-branch`, `requesting-review`; the sizing triage.
+**The pitch:** small diffs get real review — reviewers can actually hold them
+in their head — and revert cleanly when wrong. **Weaken it and:** thousand-line
+PRs get rubber-stamped and failures roll back whole features. Lighter mechanism
+first: raise the size threshold before dropping the discipline.


### PR DESCRIPTION
## Summary
- **Workflow overlay (deltas-only):** `.cogitation/config.json` gains a `workflow` manifest — `customized` gate, per-skill `enabled` / `rigidity` deltas. Upstream owns the base; user deltas survive plugin updates with nothing to merge.
- **SessionStart hook** resolves the manifest into injected per-skill posture lines (DISABLED / advisory) next to the dispatcher, shows a one-time "say customise" nudge until the gate is set, and degrades silently on missing, malformed, or wrong-typed config.
- **`values.md`:** the six core values with friction tiers — continuity-of-memory is the one HARD line; everything else is advocate-then-yield.
- **`customising` skill:** guided authoring — advocates for the affected value, offers the lighter mechanism first, yields with a recorded acknowledgment, writes deltas + persists the decision to EC.
- **Per-request proportionality:** the dispatcher now sizes every build/change request aloud (`Sizing: <tier> — <reason>`) across four tiers — TRIVIAL (just do it) / SMALL (tdd, two-way door) / MEDIUM (sketching) / FULL (brainstorming). The "too simple to need a design" red flag is replaced by "skipping the sizing announcement." Mid-flight scope growth forces an announced re-size; sizing vetoes feed EC calibration.
- **`sketching` skill (MEDIUM path):** one half-page combo doc in `docs/sketches/` (what/why, approach + rejected alternative, risks, 2–5 task checklist) instead of the design-doc + plan pair, with full TDD/verification discipline.
- cog-init and config skills wired for the gate, scaffold, and manifest schema; plugin bumped to 0.7.0.

## Test Plan
- [x] `bats` suite: 14 tests across hook (fixture-driven via `EC_COG_CONFIG`) and structural skill smoke tests — all green
- [x] `shellcheck cogitation/hooks/session-start.sh` clean
- [x] `make test` (Go suite) unaffected
- [ ] Manual smoke: fresh session in an uncustomized repo → nudge appears once; `customise` → advocacy + posture line next session

## EC Context
- Consulted: bats + env-override test pattern (`scripts/ec-ensure-api.bats`), realistic-fixture learning (#240), decisions #246/#247 (mechanism + values taxonomy)
- Pending (EC API currently rejecting writes): triage/sketching decision + bats structural-test pattern

---
Design: docs/designs/2026-06-09-customizable-workflow.md
Plan: docs/plans/2026-06-09-customizable-workflow.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)