### PR TITLE
fix(mcp): error-path outputs marshal memories as [], not null

### DIFF
--- a/internal/mcptypes/types.go
+++ b/internal/mcptypes/types.go
@@ -77,6 +77,19 @@ func ErrorResult(msg string) *mcp.CallToolResult {
 	}
 }
 
+// EmptySearchOutput returns a SearchOutput whose memories field marshals as
+// [] rather than null — the SDK validates structured output against the
+// schema even on error results, so a nil slice masks the real error.
+func EmptySearchOutput() SearchOutput {
+	return SearchOutput{Memories: []types.Memory{}}
+}
+
+// EmptyListOutput returns a ListOutput whose memories field marshals as []
+// rather than null (see EmptySearchOutput).
+func EmptyListOutput() ListOutput {
+	return ListOutput{Memories: []types.Memory{}}
+}
+
 // DefaultSearchLimit returns a default limit for search operations
 func DefaultSearchLimit(limit int) int {
 	if limit <= 0 {

--- a/internal/shim/tools.go
+++ b/internal/shim/tools.go
@@ -56,19 +56,19 @@ func (h *Handler) Add(ctx context.Context, _ *mcp.CallToolRequest, input mcptype
 
 func (h *Handler) Search(ctx context.Context, _ *mcp.CallToolRequest, input mcptypes.SearchInput) (*mcp.CallToolResult, mcptypes.SearchOutput, error) {
 	if input.Query == "" {
-		return mcptypes.ErrorResult("query is required"), mcptypes.SearchOutput{}, nil
+		return mcptypes.ErrorResult("query is required"), mcptypes.EmptySearchOutput(), nil
 	}
 
 	limit := mcptypes.DefaultSearchLimit(input.Limit)
 
 	memories, err := h.client.Search(ctx, input.Query, limit, input.Type, input.Area)
 	if err != nil {
-		return mcptypes.ErrorResult(fmt.Sprintf("failed to search: %v", err)), mcptypes.SearchOutput{}, nil
+		return mcptypes.ErrorResult(fmt.Sprintf("failed to search: %v", err)), mcptypes.EmptySearchOutput(), nil
 	}
 
 	result, fmtErr := mcptypes.MemoriesResult(memories, "No matching memories found.")
 	if fmtErr != nil {
-		return mcptypes.ErrorResult(fmtErr.Error()), mcptypes.SearchOutput{}, nil
+		return mcptypes.ErrorResult(fmtErr.Error()), mcptypes.EmptySearchOutput(), nil
 	}
 	if memories == nil {
 		memories = []types.Memory{}
@@ -99,12 +99,12 @@ func (h *Handler) List(ctx context.Context, _ *mcp.CallToolRequest, input mcptyp
 
 	memories, err := h.client.List(ctx, limit, input.Type, input.Area, input.IncludeInvalid)
 	if err != nil {
-		return mcptypes.ErrorResult(fmt.Sprintf("failed to list: %v", err)), mcptypes.ListOutput{}, nil
+		return mcptypes.ErrorResult(fmt.Sprintf("failed to list: %v", err)), mcptypes.EmptyListOutput(), nil
 	}
 
 	result, fmtErr := mcptypes.MemoriesResult(memories, "No memories found.")
 	if fmtErr != nil {
-		return mcptypes.ErrorResult(fmtErr.Error()), mcptypes.ListOutput{}, nil
+		return mcptypes.ErrorResult(fmtErr.Error()), mcptypes.EmptyListOutput(), nil
 	}
 	if memories == nil {
 		memories = []types.Memory{}

--- a/internal/shim/tools_test.go
+++ b/internal/shim/tools_test.go
@@ -2,7 +2,9 @@ package shim_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -235,6 +237,43 @@ func TestShimHandler_Search_NoResults(t *testing.T) {
 	}
 	if len(output.Memories) != 0 {
 		t.Errorf("expected 0 memories, got %d", len(output.Memories))
+	}
+}
+
+// Error-path outputs must still satisfy the output schema: a nil Memories
+// slice marshals to null, which fails SDK output validation and masks the
+// real error (seen live when the embedder was down).
+func TestShimHandler_Search_ClientError_OutputMarshalsMemoriesAsArray(t *testing.T) {
+	client := &mockAPIClient{searchErr: errors.New("api down")}
+	handler := shim.NewHandler(client)
+
+	result, output, _ := handler.Search(context.Background(), nil, mcptypes.SearchInput{Query: "anything"})
+	if !result.IsError {
+		t.Fatal("expected error result when client fails")
+	}
+	b, err := json.Marshal(output)
+	if err != nil {
+		t.Fatalf("marshal output: %v", err)
+	}
+	if !strings.Contains(string(b), `"memories":[]`) {
+		t.Errorf("error-path output must marshal memories as [], got %s", b)
+	}
+}
+
+func TestShimHandler_List_ClientError_OutputMarshalsMemoriesAsArray(t *testing.T) {
+	client := &mockAPIClient{listErr: errors.New("api down")}
+	handler := shim.NewHandler(client)
+
+	result, output, _ := handler.List(context.Background(), nil, mcptypes.ListInput{})
+	if !result.IsError {
+		t.Fatal("expected error result when client fails")
+	}
+	b, err := json.Marshal(output)
+	if err != nil {
+		t.Fatalf("marshal output: %v", err)
+	}
+	if !strings.Contains(string(b), `"memories":[]`) {
+		t.Errorf("error-path output must marshal memories as [], got %s", b)
 	}
 }
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -67,7 +67,7 @@ func (h *Handler) Add(ctx context.Context, req *mcp.CallToolRequest, input mcpty
 
 func (h *Handler) Search(ctx context.Context, req *mcp.CallToolRequest, input mcptypes.SearchInput) (*mcp.CallToolResult, mcptypes.SearchOutput, error) {
 	if input.Query == "" {
-		return mcptypes.ErrorResult("query is required"), mcptypes.SearchOutput{}, nil
+		return mcptypes.ErrorResult("query is required"), mcptypes.EmptySearchOutput(), nil
 	}
 
 	limit := mcptypes.DefaultSearchLimit(input.Limit)
@@ -82,12 +82,12 @@ func (h *Handler) Search(ctx context.Context, req *mcp.CallToolRequest, input mc
 	}
 
 	if err != nil {
-		return mcptypes.ErrorResult(fmt.Sprintf("failed to search: %v", err)), mcptypes.SearchOutput{}, nil
+		return mcptypes.ErrorResult(fmt.Sprintf("failed to search: %v", err)), mcptypes.EmptySearchOutput(), nil
 	}
 
 	result, fmtErr := mcptypes.MemoriesResult(memories, "No matching memories found.")
 	if fmtErr != nil {
-		return mcptypes.ErrorResult(fmtErr.Error()), mcptypes.SearchOutput{}, nil
+		return mcptypes.ErrorResult(fmtErr.Error()), mcptypes.EmptySearchOutput(), nil
 	}
 	if memories == nil {
 		memories = []types.Memory{}
@@ -126,12 +126,12 @@ func (h *Handler) List(ctx context.Context, req *mcp.CallToolRequest, input mcpt
 	}
 
 	if err != nil {
-		return mcptypes.ErrorResult(fmt.Sprintf("failed to list: %v", err)), mcptypes.ListOutput{}, nil
+		return mcptypes.ErrorResult(fmt.Sprintf("failed to list: %v", err)), mcptypes.EmptyListOutput(), nil
 	}
 
 	result, fmtErr := mcptypes.MemoriesResult(memories, "No memories found.")
 	if fmtErr != nil {
-		return mcptypes.ErrorResult(fmtErr.Error()), mcptypes.ListOutput{}, nil
+		return mcptypes.ErrorResult(fmtErr.Error()), mcptypes.EmptyListOutput(), nil
 	}
 	if memories == nil {
 		memories = []types.Memory{}

--- a/scripts/ec-ensure-api.bats
+++ b/scripts/ec-ensure-api.bats
@@ -16,3 +16,13 @@
   [[ "$output" == *"--name engram-cogitator-api"* ]]
   [[ "$output" == *"--storage-driver sqlite"* ]]
 }
+
+@test "dry-run prints ollama ensure with volume and restart policy" {
+  EC_DRY_RUN=1 run bash scripts/ec-ensure-api.sh
+  [[ "$output" == *"--name engram-ollama"* ]]
+  [[ "$output" == *"ollama_data:/root/.ollama"* ]]
+  [[ "$output" == *"ollama/ollama"* ]]
+  # both containers get a restart policy — an unrestarted embedder 500s the API
+  ollama_line="$(printf '%s\n' "$output" | grep -- '--name engram-ollama')"
+  [[ "$ollama_line" == *"--restart unless-stopped"* ]]
+}

--- a/scripts/ec-ensure-api.sh
+++ b/scripts/ec-ensure-api.sh
@@ -32,11 +32,36 @@ DOCKER_RUN=(docker run -d
   --db-path "/data/$(basename "$EC_DB_PATH")"
   --ollama-url http://engram-ollama:11434)
 
-if [ -n "${EC_DRY_RUN:-}" ]; then printf '%s ' "${DOCKER_RUN[@]}"; echo; exit 0; fi
+# The embedder: without it the API is "healthy" but 500s on every add/search.
+OLLAMA_NAME="engram-ollama"
+OLLAMA_IMAGE="${EC_OLLAMA_IMAGE:-ollama/ollama:latest}"
+OLLAMA_RUN=(docker run -d
+  --name "$OLLAMA_NAME"
+  --restart unless-stopped
+  --network "$NETWORK"
+  -v ollama_data:/root/.ollama
+  "$OLLAMA_IMAGE")
+
+if [ -n "${EC_DRY_RUN:-}" ]; then
+  printf '%s ' "${DOCKER_RUN[@]}"; echo
+  printf '%s ' "${OLLAMA_RUN[@]}"; echo
+  exit 0
+fi
 
 # Ensure docker + network
 command -v docker >/dev/null || { echo "docker not found; use ec-run.sh offline fallback" >&2; exit 1; }
 docker network inspect "$NETWORK" &>/dev/null || docker network create "$NETWORK" &>/dev/null || true
+
+# Ensure the embedder up first (the API depends on it for every add/search).
+# docker update fixes legacy containers created without a restart policy —
+# that gap once left the embedder down for weeks while the API stayed "up".
+ostate="$(docker inspect -f '{{.State.Running}}' "$OLLAMA_NAME" 2>/dev/null || echo missing)"
+case "$ostate" in
+  true) : ;;
+  false) docker start "$OLLAMA_NAME" &>/dev/null ;;
+  *) "${OLLAMA_RUN[@]}" &>/dev/null ;;
+esac
+docker update --restart unless-stopped "$OLLAMA_NAME" &>/dev/null || true
 
 # Ensure singleton api up
 state="$(docker inspect -f '{{.State.Running}}' "$API_NAME" 2>/dev/null || echo missing)"


### PR DESCRIPTION
## Summary
- `ec_search`/`ec_list` error paths returned zero-value output structs; a nil `Memories` slice marshals to JSON `null`, which fails the go-sdk's output-schema validation **even on IsError results** — so the client sees `validating /properties/memories: type null, want array` instead of the real error.
- Seen live: the `engram-ollama` container being down surfaced as that schema violation, hiding the actual `failed to generate embedding: ... no such host` error.
- Fix: `mcptypes.EmptySearchOutput()` / `EmptyListOutput()` helpers returning non-nil slices; all ten error-return sites in `internal/shim` and `internal/tools` swapped.
- **Also:** `ec-ensure-api.sh` now ensures the `engram-ollama` embedder container too (start-or-create, `--restart unless-stopped`, plus `docker update` for legacy containers created without a restart policy). The API had a restart policy but the embedder didn't — the gap that left EC half-broken for two weeks.

## Test Plan
- [x] New regression tests: `TestShimHandler_{Search,List}_ClientError_OutputMarshalsMemoriesAsArray` (RED before fix: `{"memories":null}`)
- [x] `bats scripts/ec-ensure-api.bats` — 4 tests incl. new ollama dry-run assertions + shellcheck
- [x] `make test` green across all packages; `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)